### PR TITLE
Update installation pre-requisites when using MacPorts on Mac OS X 10.10.

### DIFF
--- a/install_prereqs.sh
+++ b/install_prereqs.sh
@@ -3,6 +3,8 @@
 case $1 in
   ("homebrew")
     brew install cmake pkg-config gmp openblas && easy_install pip && pip install -r python_requirements.txt ;;
+  ("macports")
+    port install cmake gmp openblas swig python27 py-pip py-scipy py-numpy py-matplotlib py-nose ;;
   ("ubuntu")
     apt-get install cmake build-essential libgmp-dev python-pip liblapack-dev libblas-dev gfortran python-scipy python-numpy python-matplotlib python-nose ;;
   (*)


### PR DESCRIPTION
This commit updates the install_prereqs.sh script to install cmake,
gmp, openblas, swig, python27, py-pip, py-scipy, py-numpy, py-matplotlib
and py-nose using MacPorts-2.3.4, on Mac OS X 10.10.

Signed-off-by: Elvis Dowson <elvis.dowson@gmail.com>