### PR TITLE
ignore build artifact (placed in source).  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pod-build
 *.pyc
 build/
 externals_config.cmake
+iris_wrapper.py


### PR DESCRIPTION
@rdeits might prefer to build it to an out-of-source dir, but this is the easy fix.

(the symptom is that iris always presents itself as dirty using the new submodule-based external project handling in drake)
