### PR TITLE
Update cddlib URL to use Drake's Amazon mirror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 if (IRIS_WITH_CDD)
 	set(CDD_PROJECT_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/cdd_project-prefix/src/cdd_project)
 	ExternalProject_Add(cdd_project
-		URL ftp://ftp.ifor.math.ethz.ch/pub/fukuda/cdd/cddlib-094h.tar.gz
+		URL https://s3.amazonaws.com/drake-provisioning/cddlib-094h.tar.gz
 		PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/cdd.patch
     CONFIGURE_COMMAND ${CDD_PROJECT_SRC_DIR}/configure --prefix=${CMAKE_INSTALL_PREFIX}
     BUILD_COMMAND make


### PR DESCRIPTION
Closes #41.

I've tested this on Ubuntu 16.04.  After a fresh clone, `make` runs to completion with no errors -- the download is successful from the new s3 server.

I also tried `make check`, but several tests are failing for me for lack of `jupyter`, and I didn't immediately see how to install that.

@rdeits please double check that this builds and works for you before merging.

Thanks!