### PR TITLE
Fix cddlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 if (IRIS_WITH_CDD)
 	set(CDD_PROJECT_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/cdd_project-prefix/src/cdd_project)
 	ExternalProject_Add(cdd_project
-		URL https://s3.amazonaws.com/drake-provisioning/cddlib-094h.tar.gz
+		URL http://terminator.robots.inf.ed.ac.uk/public/cddlib-094h.tar.gz
 		PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/cdd.patch
     CONFIGURE_COMMAND ${CDD_PROJECT_SRC_DIR}/configure --prefix=${CMAKE_INSTALL_PREFIX}
     BUILD_COMMAND make


### PR DESCRIPTION
The sha256sum were different from the Drake S3 tarball and the one we had on a working legacy system:
```bash
$ sha256sum original_cddlib-094h.tar.gz drake_cddlib-094h.tar.gz
fe6d04d494683cd451be5f6fe785e147f24e8ce3ef7387f048e739ceb4565ab5  original_cddlib-094h.tar.gz
6330b766690da30991c207ab75c96f7f57813273ee894e78d78506bebc6184c4  drake_cddlib-094h.tar.gz
```

I've uploaded it to one of our servers and it compiles fine on Ubuntu 14.04. Perhaps @jwnimmer-tri wants to upload it to S3 if it works