### PR TITLE
Change cddlib to GitHub tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,8 @@ if(IRIS_WITH_CDD)
 
   ExternalProject_Add(cdd
     DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/cdd-download"
-    URL https://github.com/cddlib/cddlib/releases/download/0.94j/cddlib-0.94j.tar.gz
-    URL_MD5 73e5f7dfa72b5c3339c09564721813d6
+    URL https://github.com/cddlib/cddlib/archive/0.94h.tar.gz
+    URL_MD5 ed36310fef7e9d9669d1c4748ea62fc7
     TLS_VERIFY 1
     SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/cdd-src"
     PATCH_COMMAND "${PATCH_EXECUTABLE}" -p1 < "${CMAKE_CURRENT_SOURCE_DIR}/cdd.patch"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,8 @@ if(IRIS_WITH_CDD)
 
   ExternalProject_Add(cdd
     DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/cdd-download"
-    URL https://github.com/cddlib/cddlib/archive/0.94h.tar.gz
-    URL_MD5 ed36310fef7e9d9669d1c4748ea62fc7
+    URL http://terminator.robots.inf.ed.ac.uk/public/cddlib-094h.tar.gz
+    URL_MD5 1467d270860bbcb26d3ebae424690e7c
     TLS_VERIFY 1
     SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/cdd-src"
     PATCH_COMMAND "${PATCH_EXECUTABLE}" -p1 < "${CMAKE_CURRENT_SOURCE_DIR}/cdd.patch"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,8 @@ if(IRIS_WITH_CDD)
 
   ExternalProject_Add(cdd
     DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/cdd-download"
-    URL https://d2tbce6hkathzp.cloudfront.net/other/cddlib/cddlib-094h.tar.gz
-    URL_HASH SHA256=fe6d04d494683cd451be5f6fe785e147f24e8ce3ef7387f048e739ceb4565ab5
+    URL https://github.com/cddlib/cddlib/releases/download/0.94j/cddlib-0.94j.tar.gz
+    URL_MD5 73e5f7dfa72b5c3339c09564721813d6
     TLS_VERIFY 1
     SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/cdd-src"
     PATCH_COMMAND "${PATCH_EXECUTABLE}" -p1 < "${CMAKE_CURRENT_SOURCE_DIR}/cdd.patch"


### PR DESCRIPTION
The Cloudfront one is blocked from the UK. cddlib recently started to host their project on GitHub instead of the old FTP server, so changing it to GitHub tag tarball.

Resolves #72 