### PR TITLE
Update Eigen URL and Hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,8 @@ set(IRIS_DEPENDENCIES)
 if(IRIS_WITH_EIGEN)
   ExternalProject_Add(eigen3
     DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/eigen3-download"
-    URL https://bitbucket.org/eigen/eigen/get/3.3.3.tar.gz
-    URL_HASH SHA256=94878cbfa27b0d0fbc64c00d4aafa137f678d5315ae62ba4aecddbd4269ae75f
+    URL https://gitlab.com/libeigen/eigen/-/archive/3.3.3/eigen-3.3.3.tar.gz
+    URL_HASH SHA256=fd72694390bd8e81586205717d2cf823e718f584b779a155db747d1e68481a2e
     TLS_VERIFY 1
     SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/eigen3-src"
     CMAKE_ARGS


### PR DESCRIPTION
Eigen was transferred from BitBucket to GitLab, this change will update the download URL and hash to the new hosting.